### PR TITLE
Check return value of get_distribution()

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -842,7 +842,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
         info.update(dict(msg="OK (%s bytes)" % r.headers.get('Content-Length', 'unknown'), status=200))
     except NoSSLError, e:
         distribution = get_distribution()
-        if distribution.lower() == 'redhat':
+        if distribution is not None and distribution.lower() == 'redhat':
             module.fail_json(msg='%s. You can also install python-ssl from EPEL' % str(e))
         else:
             module.fail_json(msg='%s' % str(e))


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Ansible Version:

```
ansible 2.0.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### Summary:

On non-Linux systems `get_distribution()` returns `None`, which fails in `fetch_url`, because the return value of `get_distribution()` is not checked before calling `lower()` on the result.
##### Example output:

Before fix:

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'NoneType' object has no attribute 'lower'
fatal: [10.0.90.65]: FAILED! => {"changed": false, "failed": true, "parsed": false}
```
